### PR TITLE
Feature: Share attribute

### DIFF
--- a/app/js/addthis.js
+++ b/app/js/addthis.js
@@ -49,9 +49,7 @@ angular.module("sn.addthis", [])
             restrict: "EAC",
             replace: false,
             scope: {
-                url: "@",
-                title: "@",
-                description: "@",
+                share: "="
             },
             link: function ($scope, $element) {
 
@@ -69,17 +67,6 @@ angular.module("sn.addthis", [])
                  * @type     {Object}
                  */
                 $scope.config = $window.addthis_config ? $window.addthis_config : {}; // jshint ignore:line
-
-                /**
-                 * {@link http://support.addthis.com/customer/portal/articles/1337996-the-addthis_share-variable}
-                 * @property share
-                 * @type     {Object}
-                 */
-                $scope.share = {
-                    url: $scope.url,
-                    title : $scope.title,
-                    description : $scope.description
-                };
 
                 /**
                  * Removes the stock addthis buttons

--- a/tests/unit/addthis.js
+++ b/tests/unit/addthis.js
@@ -18,7 +18,7 @@ describe("directive: snAddthisToolbox", function() {
         timeout = $injector.get("$timeout");
 
         element =
-            "<sn-addthis-toolbox data-url=\"http://www.my-domain.com\" data-title=\"My Website\" data-description=\"foo bar\">" +
+            "<sn-addthis-toolbox data-share=\"{ url: 'http://www.my-domain.com', title: 'My Website', description: 'foo bar' }\">" +
                 "<a href class=\"addthis_button_facebook\">Facebook</a>" +
                 "<a href class=\"addthis_button_twitter\">Twitter</a>" +
             "</sn-addthis-toolbox>";
@@ -46,9 +46,9 @@ describe("directive: snAddthisToolbox", function() {
     describe("no existing config data", function() {
 
         it("should attach directive options to scope", function (){
-            expect(isolatedScope.url).toEqual("http://www.my-domain.com");
-            expect(isolatedScope.title).toEqual("My Website");
-            expect(isolatedScope.description).toEqual("foo bar");
+            expect(isolatedScope.share.url).toEqual("http://www.my-domain.com");
+            expect(isolatedScope.share.title).toEqual("My Website");
+            expect(isolatedScope.share.description).toEqual("foo bar");
         });
 
         it("should attempt to remove stock addthis buttons", function (){


### PR DESCRIPTION
Instead of specifying the `title`, `url` and `description` in separate attributes, use one attribute e.g. `data-share` which takes an object with any share options. This allows for more flexibility and future proofing.

before:
```javascript
<sn-addthis-toolbox class="addthis_custom_sharing" data-url="http://myurl.com" data-title="foo" data-description="Lorem ipsum dolor sit amet, consectetur adipiscing elit.">
    <a href class="addthis_button_facebook">Facebook</a>
</sn-addthis-toolbox>
```
after:
```javascript
<sn-addthis-toolbox 
    class="addthis_custom_sharing"
    data-share="{
        title: 'foo',
        url: 'http://myurl.com',
        description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
    }">
    <a href class="addthis_button_facebook">Facebook</a>
</sn-addthis-toolbox>
```
### Note
This is a breaking change and will result in a minor version bump

Fixes #10